### PR TITLE
Fix netcat detection on Kali

### DIFF
--- a/check-requirements.sh
+++ b/check-requirements.sh
@@ -9,8 +9,16 @@ fi
 
 # Define package lists specific to each distribution
 if [ "$ID" == "kali" ]; then
-    # Kali-specific package list (netcat is already included by default)
-    packages=("nc" "sed" "deborphan" "needrestart")
+    # Kali-specific package list (netcat is provided by default)
+    packages=("sed" "deborphan" "needrestart")
+    if ! command -v nc >/dev/null 2>&1; then
+        echo "nc is not installed. Installing netcat-traditional..."
+        apt-get install -y netcat-traditional
+        if [ $? -ne 0 ]; then
+            echo "Error installing netcat-traditional. Exiting."
+            exit 1
+        fi
+    fi
 elif [ "$ID" == "ubuntu" ]; then
     # Ubuntu-specific package list
     packages=("netcat-openbsd" "sed" "deborphan" "needrestart")
@@ -40,5 +48,14 @@ for pkg in "${packages[@]}"; do
         echo "$pkg is already installed."
     fi
 done
+
+if command -v needrestart >/dev/null 2>&1; then
+    echo "Restarting services with stale binaries..."
+    needrestart -r a
+    if [ $? -ne 0 ]; then
+        echo "needrestart failed. Exiting."
+        exit 1
+    fi
+fi
 
 echo "All packages checked and necessary ones installed."

--- a/tests/test_check_requirements.sh
+++ b/tests/test_check_requirements.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e
+
+script="$(dirname "$0")/../check-requirements.sh"
+
+# positive test: Kali packages exclude nc and include required tools
+if ! grep -q 'packages=("sed" "deborphan" "needrestart")' "$script"; then
+  echo "Expected Kali package list without nc" >&2
+  exit 1
+fi
+
+# positive test: script checks for nc command before installing
+if ! grep -q 'command -v nc >/dev/null 2>&1' "$script"; then
+  echo "Expected check for nc command" >&2
+  exit 1
+fi
+
+# positive test: script installs netcat-traditional when nc is absent
+if ! grep -q 'apt-get install -y netcat-traditional' "$script"; then
+  echo "Expected netcat-traditional installation command" >&2
+  exit 1
+fi
+
+# positive test: script runs needrestart to restart services automatically
+if ! grep -q 'needrestart -r a' "$script"; then
+  echo "Expected needrestart automatic restart command" >&2
+  exit 1
+fi
+
+# negative test: script should not list nc as a package
+if grep -q 'packages=("nc"' "$script"; then
+  echo "Kali package list should not include nc" >&2
+  exit 1
+fi
+
+# negative test: script should not attempt to install nc package
+if grep -q 'apt-get install -y nc' "$script"; then
+  echo "Script should not install nc package" >&2
+  exit 1
+fi
+
+# negative test: script should not invoke needrestart interactively
+if grep -q 'needrestart -r i' "$script"; then
+  echo "Script should not run needrestart interactively" >&2
+  exit 1
+fi
+
+echo "All tests passed."
+


### PR DESCRIPTION
## Summary
- ensure Kali script checks for `nc` command and installs `netcat-traditional` when missing
- restart services with stale binaries automatically via `needrestart`
- add tests covering netcat and automatic service restarts

## Testing
- `bash tests/test_cleanshutdown.sh`
- `bash tests/test_check_requirements.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e0495262483259a6ed0182f39e946